### PR TITLE
pass $this->request when instantiating a matcher

### DIFF
--- a/src/View/Helper/MenuHelper.php
+++ b/src/View/Helper/MenuHelper.php
@@ -38,7 +38,7 @@ class MenuHelper extends Helper
         }
 
         if (!is_object($matcher)) {
-            $matcher = new $matcher;
+            $matcher = new $matcher($this->request);
         }
 
         if (!is_object($renderer)) {


### PR DESCRIPTION
`$this->request` isn't passed when a matcher object is instantiated from a class, which causes it to fail if it's modelled after the plugin's own matcher.

To replicate, pass '\Gourmet\KnpMenu\Menu\Matcher\Matcher' as 'matcher' option when rendering the menu.
